### PR TITLE
Fix invalid memory write.

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -170,17 +170,17 @@ int format_line(const char *line,
 
     // Search the all of PATTERN in the line.
     while (search_by(line + offset, line_len - offset, pattern, pattern_len, t, &matches[match_count], thread_no)) {
-        // Two times memory will be reallocated if match size is not enough.
-        if (n <= match_count) {
-            n *= 2;
-            matches = (match *)hw_realloc(matches, sizeof(match) * n);
-        }
-
         matches[match_count].start += offset;
         matches[match_count].end   += offset;
         offset = matches[match_count].end;
 
         match_count++;
+
+        // Two times memory will be reallocated if match size is not enough.
+        if (n <= match_count) {
+            n *= 2;
+            matches = (match *)hw_realloc(matches, sizeof(match) * n);
+        }
     }
 
     // Allocate memory for colorized result string.


### PR DESCRIPTION
Fix invalid memory write reported by valgrind.
- run

```
$ valgrind --leak-check=full --show-reachable=yes ./hw - > /dev/null 
```
- log

```
==7581== Invalid write of size 4
==7581==    at 0x403762: ch (search.c:86)
==7581==    by 0x4037FA: search_by (search.c:113)
==7581==    by 0x403ADE: format_line (search.c:172)
==7581==    by 0x40427A: search_buffer (search.c:358)
==7581==    by 0x404574: search (search.c:427)
==7581==    by 0x403506: search_worker (worker.c:169)
==7581==    by 0x5145181: start_thread (pthread_create.c:312)
==7581==    by 0x545547C: clone (clone.S:111)
==7581==  Address 0x5aaa148 is 0 bytes after a block of size 200 alloc'd
==7581==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==7581==    by 0x406208: hw_malloc (hwmalloc.c:7)
==7581==    by 0x403A5D: format_line (search.c:165)
==7581==    by 0x40427A: search_buffer (search.c:358)
==7581==    by 0x404574: search (search.c:427)
==7581==    by 0x403506: search_worker (worker.c:169)
==7581==    by 0x5145181: start_thread (pthread_create.c:312)
==7581==    by 0x545547C: clone (clone.S:111)
```
