### PR TITLE
Fix memory leak

### DIFF
--- a/include/line_list.h
+++ b/include/line_list.h
@@ -20,6 +20,7 @@ struct _match_line_node {
 struct _match_line_list {
     match_line_node *first;
     match_line_node *last;
+    match_line_node *current_for_search;
     int max_line_no;
 };
 

--- a/src/line_list.c
+++ b/src/line_list.c
@@ -6,6 +6,7 @@ match_line_list *create_match_line_list()
     match_line_list *list = (match_line_list *)hw_malloc(sizeof(match_line_list));
     list->first = NULL;
     list->last  = NULL;
+    list->current_for_search = NULL;
     list->max_line_no = 1;
     return list;
 }
@@ -20,6 +21,7 @@ match_line_node *enqueue_match_line(match_line_list *list, match_line_node *node
     } else {
         list->first = node;
         list->last  = node;
+        list->current_for_search = node;
     }
 
     return node;
@@ -27,10 +29,10 @@ match_line_node *enqueue_match_line(match_line_list *list, match_line_node *node
 
 match_line_node *dequeue_match_line(match_line_list *list)
 {
-    if (list->first) {
-        match_line_node *first = list->first;
-        list->first = first->next;
-        return first;
+    if (list->current_for_search) {
+        match_line_node *current_for_search = list->current_for_search;
+        list->current_for_search = current_for_search->next;
+        return current_for_search;
     } else {
         return NULL;
     }
@@ -47,6 +49,7 @@ void clear_line_list(match_line_list *list) {
 
     list->first = NULL;
     list->last  = NULL;
+    list->current_for_search = NULL;
     list->max_line_no = 1;
 }
 

--- a/src/print.c
+++ b/src/print.c
@@ -5,6 +5,7 @@
 #include "option.h"
 #include "util.h"
 #include "color.h"
+#include "hwmalloc.h"
 
 void print_filename(const char *filename)
 {
@@ -112,5 +113,7 @@ void print_result(file_queue_node *current)
             fputs(out, stdout);
         }
         putc('\n', stdout);
+        tc_free(match_line->line);
+        tc_free(match_line);
     }
 }

--- a/src/print.c
+++ b/src/print.c
@@ -5,7 +5,6 @@
 #include "option.h"
 #include "util.h"
 #include "color.h"
-#include "hwmalloc.h"
 
 void print_filename(const char *filename)
 {
@@ -113,7 +112,5 @@ void print_result(file_queue_node *current)
             fputs(out, stdout);
         }
         putc('\n', stdout);
-        tc_free(match_line->line);
-        tc_free(match_line);
     }
 }

--- a/src/util.c
+++ b/src/util.c
@@ -97,6 +97,8 @@ void close_iconv()
 {
     iconv_close(euc_ic);
     iconv_close(sjis_ic);
+    iconv_close(utf8_euc_ic);
+    iconv_close(utf8_sjis_ic);
 }
 
 void to_euc(char *in, size_t nin, char *out, size_t nout)


### PR DESCRIPTION
Fix memory leak reported by valgrind.
- run

```
$ valgrind --leak-check=full --show-reachable=yes ./hw - > /dev/null 
```
- log 1

```
==12046== 128 bytes in 1 blocks are still reachable in loss record 1 of 10
==12046==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==12046==    by 0x537DDCB: __gconv_open (gconv_open.c:195)
==12046==    by 0x537D8E1: iconv_open (iconv_open.c:71)
==12046==    by 0x4059FE: init_iconv (util.c:92)
==12046==    by 0x4023EE: main (highway.c:105)
```
- log 2

```
==12046== 143,808 bytes in 5,992 blocks are indirectly lost in loss record 8 of 10
==12046==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==12046==    by 0x406208: hw_malloc (hwmalloc.c:7)
==12046==    by 0x403B21: format_line (search.c:188)
==12046==    by 0x40427A: search_buffer (search.c:358)
==12046==    by 0x404574: search (search.c:427)
==12046==    by 0x403506: search_worker (worker.c:169)
==12046==    by 0x5145181: start_thread (pthread_create.c:312)
==12046==    by 0x545547C: clone (clone.S:111)
```
