### PR TITLE
Forget fclose in merge_ignore_hash().

### DIFF
--- a/src/ignore.c
+++ b/src/ignore.c
@@ -94,6 +94,7 @@ ignore_hash *merge_ignore_hash(ignore_hash *hash, const char *base, const char *
         }
         add_ignore_node(hash, base, buf, depth);
     }
+    fclose(fp);
 
     return hash;
 }


### PR DESCRIPTION
Fix resource (file pointer) leak reported by valgrind.
- run

```
$ valgrind --leak-check=full --show-reachable=yes ./hw - > /dev/null 
```
- log

```
==12680== 568 bytes in 1 blocks are still reachable in loss record 1 of 1
==12680==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==12680==    by 0x53C944C: __fopen_internal (iofopen.c:73)
==12680==    by 0x404C65: merge_ignore_hash (ignore.c:79)
==12680==    by 0x402FD4: scan_target (scan.c:108)
==12680==    by 0x4026DB: process_terminal (highway.c:54)
==12680==    by 0x40242A: main (highway.c:118)
```
